### PR TITLE
fix(ui): web interface guidelines — a11y, animation, transitions, i18n, garage runtime

### DIFF
--- a/src/app/[locale]/(main)/(content)/blog/[slug]/page.tsx
+++ b/src/app/[locale]/(main)/(content)/blog/[slug]/page.tsx
@@ -94,19 +94,19 @@ export default async function BlogPostPage({ params }: Props) {
       )}
 
       {/* Title */}
-      <h1 className="text-3xl sm:text-4xl font-bold leading-tight mb-4">
+      <h1 className="text-3xl sm:text-4xl font-bold leading-tight mb-4 text-balance">
         {post.title}
       </h1>
 
       {/* Meta */}
       <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground mb-6">
         <div className="flex items-center gap-1.5">
-          <User className="h-4 w-4" />
+          <User className="h-4 w-4" aria-hidden="true" />
           {post.author.name}
         </div>
         {publishedDate && (
           <div className="flex items-center gap-1.5">
-            <Calendar className="h-4 w-4" />
+            <Calendar className="h-4 w-4" aria-hidden="true" />
             {publishedDate}
           </div>
         )}

--- a/src/app/[locale]/(main)/(content)/blog/page.tsx
+++ b/src/app/[locale]/(main)/(content)/blog/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { Metadata } from "next";
 import prisma from "@/prisma";
 import { BlogPostStatus } from "@prisma/client";
@@ -77,13 +78,13 @@ function PaginationBar({
         {sorted.map((page, i) => {
           const prev = sorted[i - 1];
           return (
-            <>
+            <React.Fragment key={page}>
               {prev && page - prev > 1 && (
-                <PaginationItem key={`ellipsis-${page}`}>
+                <PaginationItem>
                   <PaginationEllipsis />
                 </PaginationItem>
               )}
-              <PaginationItem key={page}>
+              <PaginationItem>
                 <PaginationLink
                   href={buildHref(page, q)}
                   isActive={page === currentPage}
@@ -92,7 +93,7 @@ function PaginationBar({
                   {page}
                 </PaginationLink>
               </PaginationItem>
-            </>
+            </React.Fragment>
           );
         })}
 

--- a/src/app/[locale]/(main)/(content)/setting/garage/_components/add-vehicle-dialog.tsx
+++ b/src/app/[locale]/(main)/(content)/setting/garage/_components/add-vehicle-dialog.tsx
@@ -23,13 +23,11 @@ import {
 } from "@/components/ui/select";
 import { Loader2, Plus, Search } from "lucide-react";
 
-interface Make {
-  id_car_make: number;
+interface Brand {
   name: string;
 }
 
 interface Model {
-  id_car_model: number;
   name: string;
 }
 
@@ -63,8 +61,6 @@ export function AddVehicleDialog({
 
   const [makeName, setMakeName] = useState(initialMakeName || "");
   const [modelName, setModelName] = useState(initialModelName || "");
-  const [selectedMakeId, setSelectedMakeId] = useState<number | null>(null);
-  const [selectedModelId, setSelectedModelId] = useState<number | null>(null);
   const [selectedGenerationId, setSelectedGenerationId] = useState<number | null>(
     initialGenerationId || null
   );
@@ -77,33 +73,33 @@ export function AddVehicleDialog({
   const [km, setKm] = useState("");
   const [color, setColor] = useState("");
 
-  const { data: makes = [], isFetching: makesLoading } = useQuery<Make[]>({
-    queryKey: ["makes"],
+  const { data: brands = [], isFetching: brandsLoading } = useQuery<Brand[]>({
+    queryKey: ["brands"],
     queryFn: async () => {
       const res = await axios.get("/api/car/brand");
-      return res.data;
+      return res.data.data ?? [];
     },
     enabled: open,
     staleTime: 10 * 60 * 1000,
   });
 
   const { data: models = [], isFetching: modelsLoading } = useQuery<Model[]>({
-    queryKey: ["models", selectedMakeId],
+    queryKey: ["models-by-name", makeName],
     queryFn: async () => {
-      const res = await axios.get(`/api/car/model?makeId=${selectedMakeId}`);
-      return res.data;
+      const res = await axios.get(`/api/car/model?name=${encodeURIComponent(makeName)}`);
+      return res.data.data ?? [];
     },
-    enabled: !!selectedMakeId,
+    enabled: !!makeName,
     staleTime: 10 * 60 * 1000,
   });
 
   const { data: generations = [], isFetching: generationsLoading } = useQuery<Generation[]>({
-    queryKey: ["generations", selectedModelId],
+    queryKey: ["generations-by-name", modelName],
     queryFn: async () => {
-      const res = await axios.get(`/api/car/generation?modelId=${selectedModelId}`);
-      return res.data;
+      const res = await axios.get(`/api/car/generation?model=${encodeURIComponent(modelName)}`);
+      return res.data.data ?? [];
     },
-    enabled: !!selectedModelId,
+    enabled: !!modelName,
     staleTime: 10 * 60 * 1000,
   });
 
@@ -146,10 +142,7 @@ export function AddVehicleDialog({
       resetForm();
     },
     onError: (err: unknown) => {
-      if (
-        axios.isAxiosError(err) &&
-        err.response?.status === 409
-      ) {
+      if (axios.isAxiosError(err) && err.response?.status === 409) {
         toast.error("Ce véhicule est déjà dans votre garage");
       } else {
         toast.error("Erreur lors de l'ajout");
@@ -159,12 +152,10 @@ export function AddVehicleDialog({
 
   const resetForm = () => {
     if (!initialGenerationId) {
-      setSelectedMakeId(null);
-      setSelectedModelId(null);
-      setSelectedGenerationId(null);
-      setSelectedGenerationName("");
       setMakeName("");
       setModelName("");
+      setSelectedGenerationId(null);
+      setSelectedGenerationName("");
     }
     setSelectedTrimId(null);
     setSelectedTrimName("");
@@ -193,36 +184,28 @@ export function AddVehicleDialog({
           {!initialGenerationId && (
             <>
               <div className="space-y-2">
-                <Label>Marque</Label>
-                {makesLoading ? (
+                <Label id="label-make">Marque</Label>
+                {brandsLoading ? (
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                     Chargement…
                   </div>
                 ) : (
                   <Select
                     onValueChange={(val) => {
-                      const make = makes.find(
-                        (m) => m.id_car_make === Number(val)
-                      );
-                      setSelectedMakeId(Number(val));
-                      setMakeName(make?.name || "");
-                      setSelectedModelId(null);
+                      setMakeName(val);
                       setModelName("");
                       setSelectedGenerationId(null);
                       setSelectedGenerationName("");
                     }}
                   >
-                    <SelectTrigger>
+                    <SelectTrigger aria-labelledby="label-make">
                       <SelectValue placeholder="Sélectionner une marque" />
                     </SelectTrigger>
                     <SelectContent>
-                      {makes.map((make) => (
-                        <SelectItem
-                          key={make.id_car_make}
-                          value={String(make.id_car_make)}
-                        >
-                          {make.name}
+                      {brands.map((brand) => (
+                        <SelectItem key={brand.name} value={brand.name}>
+                          {brand.name}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -230,35 +213,28 @@ export function AddVehicleDialog({
                 )}
               </div>
 
-              {selectedMakeId && (
+              {makeName && (
                 <div className="space-y-2">
-                  <Label>Modèle</Label>
+                  <Label id="label-model">Modèle</Label>
                   {modelsLoading ? (
                     <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                       Chargement…
                     </div>
                   ) : (
                     <Select
                       onValueChange={(val) => {
-                        const model = models.find(
-                          (m) => m.id_car_model === Number(val)
-                        );
-                        setSelectedModelId(Number(val));
-                        setModelName(model?.name || "");
+                        setModelName(val);
                         setSelectedGenerationId(null);
                         setSelectedGenerationName("");
                       }}
                     >
-                      <SelectTrigger>
+                      <SelectTrigger aria-labelledby="label-model">
                         <SelectValue placeholder="Sélectionner un modèle" />
                       </SelectTrigger>
                       <SelectContent>
                         {models.map((model) => (
-                          <SelectItem
-                            key={model.id_car_model}
-                            value={String(model.id_car_model)}
-                          >
+                          <SelectItem key={model.name} value={model.name}>
                             {model.name}
                           </SelectItem>
                         ))}
@@ -268,12 +244,12 @@ export function AddVehicleDialog({
                 </div>
               )}
 
-              {selectedModelId && (
+              {modelName && (
                 <div className="space-y-2">
-                  <Label>Génération</Label>
+                  <Label id="label-generation">Génération</Label>
                   {generationsLoading ? (
                     <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                       Chargement…
                     </div>
                   ) : (
@@ -286,7 +262,7 @@ export function AddVehicleDialog({
                         setSelectedGenerationName(gen?.name || "");
                       }}
                     >
-                      <SelectTrigger>
+                      <SelectTrigger aria-labelledby="label-generation">
                         <SelectValue placeholder="Sélectionner une génération" />
                       </SelectTrigger>
                       <SelectContent>
@@ -296,7 +272,8 @@ export function AddVehicleDialog({
                             value={String(gen.id_car_generation)}
                           >
                             {gen.name}
-                            {gen.year_begin && ` (${gen.year_begin}${gen.year_end ? `—${gen.year_end}` : ""})`}
+                            {gen.year_begin &&
+                              ` (${gen.year_begin}${gen.year_end ? `—${gen.year_end}` : ""})`}
                           </SelectItem>
                         ))}
                       </SelectContent>
@@ -320,7 +297,7 @@ export function AddVehicleDialog({
 
           {selectedGenerationId && trims.length > 0 && (
             <div className="space-y-2">
-              <Label>Motorisation (optionnel)</Label>
+              <Label id="label-trim">Motorisation (optionnel)</Label>
               <Select
                 onValueChange={(val) => {
                   const trim = trims.find((t) => t.id_car_trim === Number(val));
@@ -328,7 +305,7 @@ export function AddVehicleDialog({
                   setSelectedTrimName(trim?.name || "");
                 }}
               >
-                <SelectTrigger>
+                <SelectTrigger aria-labelledby="label-trim">
                   <SelectValue placeholder="Sélectionner une motorisation" />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/app/[locale]/(main)/(content)/setting/garage/_components/maintenance-dialog.tsx
+++ b/src/app/[locale]/(main)/(content)/setting/garage/_components/maintenance-dialog.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Loader2, Plus, Trash2, Wrench, Droplets } from "lucide-react";
+import { useLocale } from "next-intl";
 import type { OwnedVehicleWithMaintenance, MaintenanceEntry } from "./types";
 import { MAINTENANCE_TYPES } from "./types";
 import { cn } from "@/lib/utils";
@@ -47,6 +48,7 @@ function getTypeLabel(type: string): string {
 
 export function MaintenanceDialog({ vehicle, onClose }: MaintenanceDialogProps) {
   const queryClient = useQueryClient();
+  const locale = useLocale();
   const [showForm, setShowForm] = useState(false);
   const [type, setType] = useState("");
   const [label, setLabel] = useState("");
@@ -149,8 +151,8 @@ export function MaintenanceDialog({ vehicle, onClose }: MaintenanceDialogProps) 
                       {entry.label || getTypeLabel(entry.type)}
                     </p>
                     <p className="text-muted-foreground">
-                      {new Date(entry.date).toLocaleDateString("fr-FR")}
-                      {entry.km && ` · ${entry.km.toLocaleString("fr-FR")} km`}
+                      {new Date(entry.date).toLocaleDateString(locale)}
+                      {entry.km && ` · ${entry.km.toLocaleString(locale)} km`}
                     </p>
                     {entry.nextDueDate && (
                       <Badge
@@ -158,7 +160,7 @@ export function MaintenanceDialog({ vehicle, onClose }: MaintenanceDialogProps) 
                         className="mt-1 text-xs"
                       >
                         Prochain :{" "}
-                        {new Date(entry.nextDueDate).toLocaleDateString("fr-FR")}
+                        {new Date(entry.nextDueDate).toLocaleDateString(locale)}
                       </Badge>
                     )}
                   </div>
@@ -183,9 +185,9 @@ export function MaintenanceDialog({ vehicle, onClose }: MaintenanceDialogProps) 
             <h3 className="text-sm font-semibold">Nouvel entretien</h3>
 
             <div className="space-y-2">
-              <Label>Type</Label>
+              <Label id="label-maint-type">Type</Label>
               <Select value={type} onValueChange={setType}>
-                <SelectTrigger>
+                <SelectTrigger aria-labelledby="label-maint-type">
                   <SelectValue placeholder="Type d'entretien" />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/app/[locale]/(main)/(content)/setting/profile/change-email-form.tsx
+++ b/src/app/[locale]/(main)/(content)/setting/profile/change-email-form.tsx
@@ -51,13 +51,13 @@ export function ChangeEmailForm() {
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       {error && (
-        <Alert variant="destructive" className="animate-in fade-in-0 slide-in-from-top-2 duration-300">
+        <Alert variant="destructive" className="animate-in fade-in-0 slide-in-from-top-2 duration-300 motion-reduce:animate-none">
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
 
       {isSent && (
-        <Alert className="border-emerald-500/50 bg-emerald-500/10 animate-in fade-in-0 slide-in-from-top-2 duration-300">
+        <Alert className="border-emerald-500/50 bg-emerald-500/10 animate-in fade-in-0 slide-in-from-top-2 duration-300 motion-reduce:animate-none">
           <Mail className="h-4 w-4 text-emerald-600" aria-hidden="true" />
           <AlertDescription className="text-emerald-700 dark:text-emerald-400">
             Un email de confirmation a été envoyé. Cliquez sur le lien pour valider le changement.
@@ -97,7 +97,7 @@ export function ChangeEmailForm() {
             required
             autoComplete="email"
             spellCheck={false}
-            className={cn("transition-all", hasChanges && "border-primary/50 bg-primary/5")}
+            className={cn("transition-[border-color,background-color]", hasChanges && "border-primary/50 bg-primary/5")}
           />
         </div>
       </div>

--- a/src/app/[locale]/(main)/(content)/setting/profile/change-password-form.tsx
+++ b/src/app/[locale]/(main)/(content)/setting/profile/change-password-form.tsx
@@ -68,7 +68,7 @@ export function ChangePasswordForm() {
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       {error && (
-        <Alert variant="destructive" className="animate-in fade-in-0 slide-in-from-top-2 duration-300">
+        <Alert variant="destructive" className="animate-in fade-in-0 slide-in-from-top-2 duration-300 motion-reduce:animate-none">
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
@@ -159,7 +159,7 @@ export function ChangePasswordForm() {
       <Button
         type="submit"
         disabled={!currentPassword || !newPassword || !confirmPassword || isPending}
-        className={cn("min-w-40 transition-all", isSuccess && "bg-emerald-600 hover:bg-emerald-600")}
+        className={cn("min-w-40 transition-colors", isSuccess && "bg-emerald-600 hover:bg-emerald-600")}
       >
         {isPending ? (
           <>

--- a/src/app/[locale]/(main)/(content)/setting/profile/display-name-form.tsx
+++ b/src/app/[locale]/(main)/(content)/setting/profile/display-name-form.tsx
@@ -63,7 +63,7 @@ export function DisplayNameForm() {
             value={name}
             onChange={(e) => setName(e.target.value)}
             className={cn(
-              "transition-all",
+              "transition-[border-color,background-color]",
               hasChanges && "border-primary/50 bg-primary/5"
             )}
           />

--- a/src/app/[locale]/(main)/(content)/specification/[id]/client-page.tsx
+++ b/src/app/[locale]/(main)/(content)/specification/[id]/client-page.tsx
@@ -221,7 +221,7 @@ export function SpecificationDetailPage() {
         {/* ── Fiche technique ───────────────────────────────────────── */}
         <TabsContent
           value="fiche"
-          className="space-y-6 mt-6 outline-none print:!block"
+          className="space-y-6 mt-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 print:!block"
         >
           <AnimatedSection delay={60}>
             <MotorizationSelector
@@ -257,7 +257,7 @@ export function SpecificationDetailPage() {
         {/* ── Analyse ───────────────────────────────────────────────── */}
         <TabsContent
           value="analyse"
-          className="space-y-6 mt-6 outline-none print:!block"
+          className="space-y-6 mt-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 print:!block"
         >
           <AnimatedSection delay={60}>
             <AIReliabilityWidget
@@ -286,7 +286,7 @@ export function SpecificationDetailPage() {
         {/* ── Avis ──────────────────────────────────────────────────── */}
         <TabsContent
           value="avis"
-          className="space-y-6 mt-6 outline-none print:!block"
+          className="space-y-6 mt-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 print:!block"
         >
           <AnimatedSection delay={60}>
             <Suspense

--- a/src/app/api/car/generation/route.ts
+++ b/src/app/api/car/generation/route.ts
@@ -20,7 +20,10 @@ export const GET = async (req: Request) => {
           }
         : undefined,
       select: {
+        id_car_generation: true,
         name: true,
+        year_begin: true,
+        year_end: true,
       },
       orderBy: {
         name: "asc",


### PR DESCRIPTION
Closes #16

## Summary
- Accessibility: `aria-labelledby` on all unlabeled Select controls in garage dialogs; `aria-hidden` on decorative icons; `focus-visible:ring-*` replacing `outline-none` on TabsContent; `text-balance` on blog h1
- Animation: `motion-reduce:animate-none` added to `animate-in` alerts in profile forms
- Transitions: `transition-all` replaced with explicit properties across 3 profile forms
- i18n: `useLocale()` replaces hardcoded `"fr-FR"` in maintenance dialog
- Pagination: `React.Fragment key={page}` fixes missing key in PaginationBar `.map()`
- Runtime bug fix: `AddVehicleDialog` was calling `.map()` on `{ data: [...] }` wrapper object; rewrote to use name-based queries (`?name=` / `?model=`) matching the actual APIs, and `res.data.data` unwrap
- API: generation route now returns `id_car_generation`, `year_begin`, `year_end`

## Test plan
- [ ] Ouvrir dialog "Ajouter un véhicule" dans /setting/garage — la liste des marques s'affiche sans erreur
- [ ] Vérifier enchaînement Marque → Modèle → Génération → Motorisation fonctionne
- [ ] Navigation clavier dans les onglets Fiche/Analyse/Avis → ring visible au focus
- [ ] Réduire les animations (prefers-reduced-motion) → alerts sans animation
- [ ] Vérifier dates dans le dialog entretien correspondent à la locale active
- [ ] Pagination blog : pas d'avertissement React key dans la console

🤖 Generated with [Claude Code](https://claude.com/claude-code)