### PR TITLE
feat(car-images): images des générations de voitures (#20)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,10 @@ const nextConfig: NextConfig = {
       { protocol: "http", hostname: "localhost" },
       { protocol: "https", hostname: "cdn.pixabay.com" },
       { protocol: "https", hostname: "lh3.googleusercontent.com" },
+      { protocol: "https", hostname: "i.pravatar.cc" },
+      { protocol: "https", hostname: "upload.wikimedia.org" },
+      { protocol: "https", hostname: "cdn.imagin.studio" },
+      { protocol: "https", hostname: "www.netcarshow.com" },
     ],
   },
 };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -595,6 +595,7 @@ model CarGenerationFR {
   year_end          String?      @default("NULL")
   date_update       String?      @default("NULL")
   date_create       Int
+  image_url         String?
   carModel          CarModelFR   @relation(fields: [id_car_model], references: [id_car_model])
   carType           CarTypeFR    @relation(fields: [id_car_type], references: [id_car_type])
   series            CarSerieFR[]
@@ -787,6 +788,7 @@ model CarGenerationEN {
   year_end          String?      @default("NULL")
   date_update       String?      @default("NULL")
   date_create       Int
+  image_url         String?
   carModel          CarModelEN   @relation(fields: [id_car_model], references: [id_car_model])
   carType           CarTypeEN    @relation(fields: [id_car_type], references: [id_car_type])
   series            CarSerieEN[]

--- a/scripts/reset-car-images.ts
+++ b/scripts/reset-car-images.ts
@@ -1,0 +1,25 @@
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import "dotenv/config";
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) throw new Error("DATABASE_URL is not defined");
+const adapter = new PrismaPg({ connectionString });
+const prisma = new PrismaClient({ adapter });
+
+async function main() {
+  const fr = await prisma.carGenerationFR.updateMany({
+    where: { image_url: { not: null } },
+    data: { image_url: null },
+  });
+  const en = await prisma.carGenerationEN.updateMany({
+    where: { image_url: { not: null } },
+    data: { image_url: null },
+  });
+  console.log(`FR reset: ${fr.count}`);
+  console.log(`EN reset: ${en.count}`);
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());

--- a/scripts/seed-car-images.ts
+++ b/scripts/seed-car-images.ts
@@ -1,0 +1,490 @@
+/**
+ * seed-car-images.ts v5
+ *
+ * Sources d'images (par ordre de priorité) :
+ *  1. Wikipedia direct lookup → infobox photo  (article spécifique à la génération)
+ *  2. Wikimedia Commons search + année         (photos year-specific)
+ *  3. Wikipedia listing photo                  (fallback généraliste)
+ *
+ * Améliorations v5 :
+ *  - Normalisation du nom de modèle ("2 CV" → essaie aussi "2CV")
+ *  - Wikimedia Commons comme 2e source (recherche par année)
+ *  - Déduplication par modèle (une URL ≠ deux générations)
+ *  - Score par année dans les noms de fichiers
+ *
+ * Usage :
+ *   npx tsx scripts/seed-car-images.ts
+ *   npx tsx scripts/seed-car-images.ts --limit=20
+ *   npx tsx scripts/seed-car-images.ts --overwrite
+ *   npx tsx scripts/seed-car-images.ts --lang=en
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import "dotenv/config";
+
+// ── Prisma ────────────────────────────────────────────────────────────────────
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) throw new Error("DATABASE_URL is not defined");
+const adapter = new PrismaPg({ connectionString });
+const prisma  = new PrismaClient({ adapter });
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+const args      = process.argv.slice(2);
+const LIMIT     = (() => { const f = args.find((a) => a.startsWith("--limit=")); return f ? parseInt(f.split("=")[1], 10) : Infinity; })();
+const OVERWRITE = args.includes("--overwrite");
+const LANG      = args.find((a) => a.startsWith("--lang="))?.split("=")[1] ?? "fr";
+
+const WIKI_EN   = "https://en.wikipedia.org/w/api.php";
+const WIKI_FR   = "https://fr.wikipedia.org/w/api.php";
+const COMMONS   = "https://commons.wikimedia.org/w/api.php";
+
+const DELAY_MS  = 600;
+const UA        = "DriveMetric/1.0 (car-image-seeder)";
+
+function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+async function wikiGet(base: string, params: Record<string, string>): Promise<unknown> {
+  const u = new URL(base);
+  u.searchParams.set("format", "json");
+  u.searchParams.set("origin", "*");
+  for (const [k, v] of Object.entries(params)) u.searchParams.set(k, v);
+  const r = await fetch(u.toString(), {
+    headers: { "User-Agent": UA },
+    signal: AbortSignal.timeout(8000),
+  });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return r.json();
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const SKIP = /logo|icon|badge|flag|coat|seal|symbol|emblem|map|sign|blank|silhouet|schema|diagram|schéma/i;
+
+/** Nettoie le nom de génération (supprime brackets, "génération", etc.) */
+function cleanGen(raw: string): string {
+  return raw
+    .replace(/\[.*?\]/g, "")
+    .replace(/\b(génération|generation|gen\.?)\b/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isGenericGen(s: string): boolean {
+  return /^[IVXLCDM\d\s]*$/.test(s) || s === "";
+}
+
+/** Extrait le numéro de génération depuis "1 génération", "2 génération", etc. */
+function extractGenNumber(gen: string): number | null {
+  const m = gen.match(/^(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/** Convertit un entier (1-10) en chiffre romain */
+function toRoman(n: number): string {
+  const map: [number, string][] = [
+    [10, "X"], [9, "IX"], [8, "VIII"], [7, "VII"], [6, "VI"],
+    [5, "V"],  [4, "IV"], [3, "III"],  [2, "II"],  [1, "I"],
+  ];
+  let r = "";
+  for (const [v, s] of map) { while (n >= v) { r += s; n -= v; } }
+  return r;
+}
+
+/**
+ * Produit des variantes normalisées du nom de modèle.
+ * "2 CV" → ["2 CV", "2CV"]   "C3" → ["C3"]
+ */
+function modelVariants(model: string): string[] {
+  const base = model.trim();
+  const noInternalSpaces = base.replace(/(\d)\s+([A-Za-z])/g, "$1$2").replace(/([A-Za-z])\s+(\d)/g, "$1$2");
+  return noInternalSpaces !== base ? [base, noInternalSpaces] : [base];
+}
+
+// ── Candidates pour la recherche Wikipedia ────────────────────────────────────
+
+function buildCandidates(make: string, model: string, gen: string, year?: string | null): string[] {
+  const y       = year?.replace("NULL", "").trim();
+  const cGen    = cleanGen(gen);
+  const generic = isGenericGen(cGen);
+  const models  = modelVariants(model);
+  const candidates: string[] = [];
+
+  // 1. Cas où le gen apporte une info réelle (ex: "Clio V", "Sahara", "BX Sport")
+  if (!generic && cGen.toLowerCase() !== model.toLowerCase()) {
+    const genHasModel = cGen.toLowerCase().includes(model.toLowerCase());
+    for (const m of models) {
+      if (genHasModel) {
+        candidates.push(`${make} ${cGen}`);
+        if (y) candidates.push(`${make} ${cGen} ${y}`);
+      } else {
+        candidates.push(`${make} ${m} ${cGen}`);
+        if (y) candidates.push(`${make} ${m} ${cGen} ${y}`);
+        candidates.push(`${make} ${cGen}`);
+      }
+    }
+  }
+
+  // 2. Article spécifique à la génération via chiffre romain ("Citroën C3 I", "Citroën C3 II")
+  const genNum = extractGenNumber(gen);
+  if (genNum && genNum <= 10) {
+    const roman = toRoman(genNum);
+    for (const m of models) {
+      candidates.push(`${make} ${m} ${roman}`);
+    }
+  }
+
+  // 3. Fallback modèle seul
+  for (const m of models) {
+    if (y) candidates.push(`${make} ${m} ${y}`);
+    candidates.push(`${make} ${m}`);
+  }
+
+  return [...new Set(candidates)];
+}
+
+// ── Normalisation pour comparaison (supprime accents + espaces internes) ──────
+
+/** "Citroën 2CV" → "citroen 2cv"  |  "2 CV" → "2 cv" */
+function norm(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Vérifie que le titre Wikipedia correspond à la marque ET au modèle. */
+function titleMatchesCar(title: string, make: string, model: string): boolean {
+  const t = norm(title);
+  const makeN = norm(make);
+  // Toutes les variantes du modèle (avec/sans espace interne) normalisées
+  const modelNorms = modelVariants(model).map(norm);
+  return t.includes(makeN) && modelNorms.some((m) => t.includes(m));
+}
+
+// ── Wikipedia : lookup direct ─────────────────────────────────────────────────
+
+async function directLookup(
+  title: string,
+  make: string,
+  model: string,
+  apiBase: string
+): Promise<string | null> {
+  try {
+    const json = await wikiGet(apiBase, {
+      action: "query",
+      titles: title,
+      redirects: "1",
+    }) as { query?: { pages?: Record<string, { title: string; missing?: string }> } };
+
+    const page = Object.values(json?.query?.pages ?? {})[0];
+    if (!page || "missing" in page) return null;
+    if (titleMatchesCar(page.title, make, model)) return page.title;
+  } catch { /* fall through */ }
+  return null;
+}
+
+// ── Wikipedia : recherche texte avec validation marque + modèle ───────────────
+
+async function searchTitle(
+  query: string,
+  make: string,
+  model: string,
+  apiBase: string
+): Promise<string | null> {
+  try {
+    const json = await wikiGet(apiBase, {
+      action: "query",
+      list: "search",
+      srsearch: query,
+      srlimit: "8",
+    }) as { query?: { search?: { title: string }[] } };
+
+    for (const r of json?.query?.search ?? []) {
+      if (titleMatchesCar(r.title, make, model)) return r.title;
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+async function findWikiTitle(
+  make: string,
+  model: string,
+  gen: string,
+  year: string | null | undefined,
+  apiBase: string
+): Promise<string | null> {
+  const candidates = buildCandidates(make, model, gen, year);
+
+  // 1. Direct lookup sur les 2 premiers candidats
+  for (const c of candidates.slice(0, 2)) {
+    const title = await directLookup(c, make, model, apiBase);
+    if (title) return title;
+    await sleep(100);
+  }
+
+  // 2. Recherche texte sur tous les candidats (avec validation marque + modèle)
+  for (const c of candidates) {
+    const title = await searchTitle(c, make, model, apiBase);
+    if (title) return title;
+    await sleep(150);
+  }
+
+  return null;
+}
+
+// ── Wikipedia : infobox photo ─────────────────────────────────────────────────
+
+async function infoboxPhoto(title: string, apiBase: string): Promise<string | null> {
+  try {
+    const json = await wikiGet(apiBase, {
+      action: "query",
+      titles: title,
+      prop: "pageimages",
+      pithumbsize: "800",
+      pilimit: "1",
+    }) as { query?: { pages?: Record<string, { thumbnail?: { source: string; width: number } }> } };
+
+    const thumb = Object.values(json?.query?.pages ?? {})[0]?.thumbnail;
+    if (thumb && thumb.width >= 300) return thumb.source;
+  } catch { /* fall through */ }
+  return null;
+}
+
+// ── Wikimedia Commons : recherche par année ───────────────────────────────────
+
+async function commonsPhoto(
+  make: string,
+  model: string,
+  year: string | null | undefined,
+  usedUrls: Set<string>
+): Promise<string | null> {
+  const cleanYear = year?.replace("NULL", "").trim();
+  const models    = modelVariants(model);
+
+  // Requêtes par ordre de précision (avec année d'abord)
+  const queries: string[] = [];
+  for (const m of models) {
+    if (cleanYear) queries.push(`${make} ${m} ${cleanYear}`);
+    queries.push(`${make} ${m}`);
+  }
+
+  for (const q of [...new Set(queries)]) {
+    try {
+      const searchJson = await wikiGet(COMMONS, {
+        action: "query",
+        list: "search",
+        srsearch: q,
+        srnamespace: "6",   // namespace File uniquement
+        srlimit: "10",
+      }) as { query?: { search?: { title: string }[] } };
+
+      const files = (searchJson?.query?.search ?? [])
+        .map((r) => r.title.replace(/^File:/i, ""))
+        .filter((f) => /\.(jpe?g|webp|png)$/i.test(f) && !SKIP.test(f));
+
+      // Score : préfère les fichiers contenant l'année
+      const scored = files.map((f) => ({
+        file: f,
+        score: cleanYear && f.includes(cleanYear) ? 1 : 0,
+      }));
+      scored.sort((a, b) => b.score - a.score);
+
+      for (const { file } of scored.slice(0, 6)) {
+        try {
+          const infoJson = await wikiGet(COMMONS, {
+            action: "query",
+            titles: `File:${file}`,
+            prop: "imageinfo",
+            iiprop: "url|dimensions",
+            iiurlwidth: "640",
+          }) as { query?: { pages?: Record<string, { imageinfo?: { thumburl: string; width: number }[] }> } };
+
+          const info = Object.values(infoJson?.query?.pages ?? {})[0]?.imageinfo?.[0];
+          if (info?.thumburl && info.width >= 350 && !usedUrls.has(info.thumburl)) {
+            return info.thumburl;
+          }
+        } catch { /* try next */ }
+        await sleep(100);
+      }
+    } catch { /* try next query */ }
+    await sleep(150);
+  }
+
+  return null;
+}
+
+// ── Wikipedia : listing photo (fallback) ─────────────────────────────────────
+
+async function listingPhoto(
+  title: string,
+  apiBase: string,
+  year?: string | null,
+  usedUrls?: Set<string>
+): Promise<string | null> {
+  try {
+    const listJson = await wikiGet(apiBase, {
+      action: "query",
+      titles: title,
+      prop: "images",
+      imlimit: "40",
+    }) as { query?: { pages?: Record<string, { images?: { title: string }[] }> } };
+
+    const page  = Object.values(listJson?.query?.pages ?? {})[0];
+    const files = (page?.images ?? [])
+      .map((i) => i.title.replace(/^File:/i, ""))
+      .filter((f) => /\.(jpe?g|webp|png)$/i.test(f) && !SKIP.test(f));
+
+    if (files.length === 0) return null;
+
+    const cleanYear = year?.replace("NULL", "").trim();
+    const scored = files.map((f) => ({
+      file: f,
+      score: cleanYear && f.includes(cleanYear) ? 1 : 0,
+    }));
+    scored.sort((a, b) => b.score - a.score);
+
+    for (const { file } of scored.slice(0, 8)) {
+      try {
+        const infoJson = await wikiGet(apiBase, {
+          action: "query",
+          titles: `File:${file}`,
+          prop: "imageinfo",
+          iiprop: "url|dimensions",
+          iiurlwidth: "640",
+        }) as { query?: { pages?: Record<string, { imageinfo?: { thumburl: string; width: number }[] }> } };
+
+        const info = Object.values(infoJson?.query?.pages ?? {})[0]?.imageinfo?.[0];
+        if (info?.thumburl && info.width >= 350) {
+          if (usedUrls?.has(info.thumburl)) continue;
+          return info.thumburl;
+        }
+      } catch { /* try next */ }
+      await sleep(150);
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+// ── Orchestrator ──────────────────────────────────────────────────────────────
+
+async function getPhoto(
+  make: string,
+  model: string,
+  gen: string,
+  year: string | null | undefined,
+  usedUrls: Set<string>
+): Promise<{ url: string; method: string } | null> {
+  const cleanYear = year?.replace("NULL", "").trim();
+
+  // ── Étape 1 : Commons avec année (plus précis pour différencier les générations)
+  if (cleanYear) {
+    const commons = await commonsPhoto(make, model, year, usedUrls);
+    if (commons) return { url: commons, method: `commons:${make} ${model} ${cleanYear}` };
+    await sleep(200);
+  }
+
+  // ── Étape 2 : Wikipedia infobox (article le plus spécifique trouvé)
+  for (const [lang, apiBase] of [["en", WIKI_EN], ["fr", WIKI_FR]] as const) {
+    const title = await findWikiTitle(make, model, gen, year, apiBase);
+    if (!title) continue;
+    await sleep(200);
+    const infobox = await infoboxPhoto(title, apiBase);
+    if (infobox && !usedUrls.has(infobox)) {
+      return { url: infobox, method: `infobox(${lang}):${title}` };
+    }
+    await sleep(200);
+  }
+
+  // ── Étape 3 : Commons sans année (fallback)
+  if (!cleanYear) {
+    const commons = await commonsPhoto(make, model, year, usedUrls);
+    if (commons) return { url: commons, method: `commons:${make} ${model}` };
+    await sleep(200);
+  }
+
+  // ── Étape 4 : Wikipedia listing (dernier recours)
+  for (const [lang, apiBase] of [["en", WIKI_EN], ["fr", WIKI_FR]] as const) {
+    const title = await findWikiTitle(make, model, gen, year, apiBase);
+    if (!title) continue;
+    const listing = await listingPhoto(title, apiBase, year, usedUrls);
+    if (listing) return { url: listing, method: `listing(${lang}):${title}` };
+    await sleep(200);
+  }
+
+  return null;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const isFR    = LANG === "fr";
+  const dbModel = isFR ? prisma.carGenerationFR : prisma.carGenerationEN;
+  const where   = OVERWRITE ? {} : { image_url: null };
+
+  const total = await (dbModel as typeof prisma.carGenerationFR).count({ where });
+  const cap   = isFinite(LIMIT) ? Math.min(total, LIMIT) : total;
+
+  console.log(`\n🚗  seed-car-images v5 [lang=${LANG}] [overwrite=${OVERWRITE}]`);
+  console.log(`   Sans image   : ${total}`);
+  console.log(`   À traiter    : ${cap}\n`);
+
+  const rows = await (dbModel as typeof prisma.carGenerationFR).findMany({
+    where,
+    include: { carModel: { include: { carMake: true } } },
+    take: isFinite(LIMIT) ? LIMIT : undefined,
+    orderBy: [
+      { carModel: { carMake: { name: "asc" } } },
+      { carModel: { name: "asc" } },
+      { year_begin: "asc" },
+    ],
+  });
+
+  const usedPerModel = new Map<string, Set<string>>();
+
+  let ok = 0, nope = 0;
+
+  for (let i = 0; i < rows.length; i++) {
+    const row   = rows[i];
+    const make  = row.carModel.carMake.name;
+    const model = row.carModel.name;
+    const gen   = row.name;
+    const year  = row.year_begin;
+
+    const modelKey = `${make}|${model}`;
+    if (!usedPerModel.has(modelKey)) usedPerModel.set(modelKey, new Set());
+    const usedUrls = usedPerModel.get(modelKey)!;
+
+    process.stdout.write(`[${i + 1}/${rows.length}] ${make} ${model} — ${gen} (${year ?? "?"}) … `);
+
+    const result = await getPhoto(make, model, gen, year, usedUrls);
+
+    if (result) {
+      await (dbModel as typeof prisma.carGenerationFR).update({
+        where: { id_car_generation: row.id_car_generation },
+        data: { image_url: result.url },
+      });
+      usedUrls.add(result.url);
+      console.log(`✅  [${result.method}]`);
+      ok++;
+    } else {
+      console.log("❌  not found");
+      nope++;
+    }
+
+    await sleep(DELAY_MS);
+  }
+
+  console.log(`\n─────────────────────────────`);
+  console.log(`✅  Trouvé      : ${ok}`);
+  console.log(`❌  Introuvable : ${nope}`);
+  console.log(`─────────────────────────────\n`);
+}
+
+main()
+  .catch((e) => { console.error(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/src/app/[locale]/(main)/(content)/specification/[id]/_components/types.ts
+++ b/src/app/[locale]/(main)/(content)/specification/[id]/_components/types.ts
@@ -22,6 +22,7 @@ export interface Generation {
   name: string;
   year_begin: string | null;
   year_end: string | null;
+  image_url?: string | null;
   carModel: {
     name: string;
     carMake: {

--- a/src/app/[locale]/(main)/(content)/specification/[id]/_components/vehicle-header.tsx
+++ b/src/app/[locale]/(main)/(content)/specification/[id]/_components/vehicle-header.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useState } from "react";
 import Image from "next/image";
+import { CarIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -36,6 +37,8 @@ export function VehicleHeader({
   const modelName = generation.carModel?.name || "";
   const genName = generation.name || "";
   const logoUrl = generation.carModel?.carMake?.logo_url || null;
+  const imageUrl = generation.image_url || null;
+  const [imgErrored, setImgErrored] = useState(false);
 
   const totalTrims = useMemo(() => {
     let count = 0;
@@ -60,15 +63,41 @@ export function VehicleHeader({
     window.print();
   }, []);
 
+  const showCarImage = imageUrl && !imgErrored;
+
   return (
     <div className="relative overflow-hidden rounded-2xl bg-linear-to-br from-primary/5 via-primary/2 to-transparent border">
+      {/* Car image banner */}
+      {showCarImage ? (
+        <div className="relative w-full h-52 sm:h-64 lg:h-72 bg-muted overflow-hidden">
+          <Image
+            src={imageUrl}
+            alt={`${makeName} ${modelName} ${genName}`}
+            fill
+            sizes="(max-width: 768px) 100vw, 900px"
+            className="object-contain"
+            priority
+            unoptimized={imageUrl.includes("upload.wikimedia.org")}
+            onError={() => setImgErrored(true)}
+          />
+          {/* Logo badge en bas à droite */}
+          {logoUrl && (
+            <div
+              className="absolute bottom-3 right-3 w-10 h-10 rounded-xl bg-white/90 backdrop-blur-sm border border-white/60 shadow-md flex items-center justify-center overflow-hidden"
+              aria-hidden="true"
+            >
+              <Image src={logoUrl} alt="" width={32} height={32} className="object-contain" unoptimized />
+            </div>
+          )}
+        </div>
+      ) : null}
       <div className="p-6 lg:p-8">
         <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
-          {/* Left: brand initial + title */}
+          {/* Left: brand logo (only when no car image) + title */}
           <div className="flex items-center gap-5">
-            {logoUrl ? (
+            {!showCarImage && (logoUrl ? (
               <div
-                className="relative w-20 h-20 lg:w-32 lg:h-32 rounded-2xl  shrink-0 shadow-primary/20 overflow-hidden"
+                className="relative w-20 h-20 lg:w-32 lg:h-32 rounded-2xl shrink-0 shadow-primary/20 overflow-hidden"
                 aria-hidden="true"
               >
                 <Image
@@ -87,7 +116,7 @@ export function VehicleHeader({
               >
                 {makeName.charAt(0)}
               </div>
-            )}
+            ))}
             <div className="space-y-2">
               <h1 className="text-3xl lg:text-4xl font-bold tracking-tight font-serif text-balance">
                 {makeName} {modelName}

--- a/src/components/list/car-image.tsx
+++ b/src/components/list/car-image.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { CarIcon } from "lucide-react";
+import { getImaginstudioUrl } from "@/lib/car-image";
+import { cn } from "@/lib/utils";
+
+interface CarImageProps {
+  /** URL already stored in DB (highest priority) */
+  cachedUrl?: string | null;
+  /** Fallback: construct URL from imagin.studio */
+  make: string;
+  model: string;
+  year?: string | null;
+  alt: string;
+  logoUrl?: string | null;
+  className?: string;
+}
+
+export function CarImage({
+  cachedUrl,
+  make,
+  model,
+  year,
+  alt,
+  logoUrl,
+  className,
+}: CarImageProps) {
+  const src = cachedUrl ?? getImaginstudioUrl(make, model, year);
+  const [errored, setErrored] = useState(false);
+  const unoptimized = !!src?.includes("upload.wikimedia.org");
+
+  const showImage = src && !errored;
+
+  return (
+    <div
+      className={cn(
+        "relative w-full h-40 bg-muted overflow-hidden",
+        className
+      )}
+    >
+      {showImage ? (
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+          className="object-cover transition-transform duration-300 motion-reduce:transition-none group-hover:scale-105"
+          unoptimized={unoptimized}
+          onError={() => setErrored(true)}
+        />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center">
+          <CarIcon className="w-10 h-10 text-muted-foreground/30" aria-hidden="true" />
+        </div>
+      )}
+
+      {/* Brand logo badge */}
+      {logoUrl && showImage && (
+        <div
+          className="absolute bottom-2 right-2 w-9 h-9 rounded-md bg-white/90 backdrop-blur-sm border border-white/60 shadow flex items-center justify-center overflow-hidden"
+          aria-hidden="true"
+        >
+          <Image
+            src={logoUrl}
+            alt=""
+            width={28}
+            height={28}
+            className="object-contain"
+            unoptimized
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/list/list-specification.tsx
+++ b/src/components/list/list-specification.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
+import { CarImage } from "./car-image";
 import {
   CarIcon,
   Calendar,
@@ -16,6 +17,7 @@ interface Generation {
   name: string;
   year_begin?: string;
   year_end?: string;
+  image_url?: string | null;
   carModel: {
     name: string;
     carMake: {
@@ -52,17 +54,16 @@ export function SpecificationListSkeleton() {
       {Array.from({ length: 8 }).map((_, i) => (
         <div
           key={i}
-          className="rounded-xl border border-border bg-card p-4 animate-pulse motion-reduce:animate-none"
+          className="rounded-xl border border-border bg-card overflow-hidden animate-pulse motion-reduce:animate-none"
         >
-          <div className="flex items-center gap-3 mb-4">
-            <div className="w-12 h-12 rounded-full bg-muted" />
-            <div className="flex-1 space-y-2">
-              <div className="h-4 bg-muted rounded w-3/4" />
-              <div className="h-3 bg-muted rounded w-1/2" />
+          <div className="w-full h-40 bg-muted" />
+          <div className="p-4 space-y-3">
+            <div className="flex items-center gap-3">
+              <div className="flex-1 space-y-2">
+                <div className="h-4 bg-muted rounded w-3/4" />
+                <div className="h-3 bg-muted rounded w-1/2" />
+              </div>
             </div>
-          </div>
-          <div className="space-y-2">
-            <div className="h-3 bg-muted rounded w-full" />
             <div className="h-3 bg-muted rounded w-2/3" />
           </div>
         </div>
@@ -115,7 +116,8 @@ function SpecificationCard({
   const makeName = generation.carModel.carMake.name;
   const logoUrl = generation.carModel.carMake.logo_url;
   const modelName = generation.carModel.name;
-  const yearRange = `${generation.year_begin || "?"} — ${generation.year_end || "présent"}`;
+  const imageUrl = generation.image_url;
+  const yearRange = `${generation.year_begin || "?"}\u00a0— ${generation.year_end || "présent"}`;
 
   return (
     <Link
@@ -124,86 +126,101 @@ function SpecificationCard({
     >
       <article
         className={cn(
-          "h-full rounded-xl border border-border bg-card p-4",
+          "h-full rounded-xl border border-border bg-card overflow-hidden",
           "transition-[box-shadow,border-color] duration-200 motion-reduce:transition-none",
           "hover:shadow-lg hover:shadow-primary/5 hover:border-primary/30",
           "group-focus-visible:border-primary",
         )}
       >
-        {/* Header */}
-        <div className="flex items-start gap-3 mb-4">
-          {logoUrl ? (
-            <div
-              className="relative w-11 h-11 rounded-lg bg-white shrink-0 transition-transform motion-reduce:transition-none group-hover:scale-105 border border-border overflow-hidden"
-              aria-hidden="true"
-            >
-              <Image
-                src={logoUrl}
-                alt={`Logo ${makeName}`}
-                fill
-                sizes="44px"
-                className="object-contain"
-                quality={100}
-                unoptimized
-              />
+        {/* Car image — imagin.studio or DB override */}
+        <CarImage
+          cachedUrl={imageUrl}
+          make={makeName}
+          model={modelName}
+          year={generation.year_begin}
+          alt={`${makeName} ${modelName} ${generation.name}`}
+          logoUrl={logoUrl}
+        />
+
+        <div className="p-4">
+          {/* Header */}
+          <div className="flex items-start gap-3 mb-3">
+            {/* Logo — only show standalone when no image */}
+            {!imageUrl && (
+              logoUrl ? (
+                <div
+                  className="relative w-11 h-11 rounded-lg bg-white shrink-0 transition-transform motion-reduce:transition-none group-hover:scale-105 border border-border overflow-hidden"
+                  aria-hidden="true"
+                >
+                  <Image
+                    src={logoUrl}
+                    alt=""
+                    fill
+                    sizes="44px"
+                    className="object-contain"
+                    quality={100}
+                    unoptimized
+                  />
+                </div>
+              ) : (
+                <div
+                  className={cn(
+                    "w-11 h-11 rounded-lg flex items-center justify-center text-white text-lg font-bold shrink-0",
+                    "transition-transform motion-reduce:transition-none group-hover:scale-105",
+                    getBrandColor(makeName),
+                  )}
+                  aria-hidden="true"
+                >
+                  {makeName.charAt(0)}
+                </div>
+              )
+            )}
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <h3 className="font-semibold text-foreground truncate group-hover:text-primary transition-colors motion-reduce:transition-none">
+                  {makeName} {modelName}
+                </h3>
+                {isUnlocked && (
+                  <span className="inline-flex items-center gap-1 shrink-0 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
+                    <BadgeCheck className="h-3 w-3" aria-hidden="true" />
+                    Consulté
+                  </span>
+                )}
+              </div>
+              <p className="text-sm text-muted-foreground truncate">
+                {generation.name}
+              </p>
             </div>
-          ) : (
-            <div
-              className={cn(
-                "w-11 h-11 rounded-lg flex items-center justify-center text-white text-lg font-bold shrink-0",
-                "transition-transform motion-reduce:transition-none group-hover:scale-105",
-                getBrandColor(makeName),
-              )}
-              aria-hidden="true"
-            >
-              {makeName.charAt(0)}
-            </div>
-          )}
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <h3 className="font-semibold text-foreground truncate group-hover:text-primary transition-colors">
-                {makeName} {modelName}
-              </h3>
-              {isUnlocked && (
-                <span className="inline-flex items-center gap-1 shrink-0 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
-                  <BadgeCheck className="h-3 w-3" aria-hidden="true" />
-                  Consulté
+          </div>
+
+          {/* Metadata */}
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground mb-4">
+            <span className="flex items-center gap-1.5">
+              <Calendar className="w-3.5 h-3.5" aria-hidden="true" />
+              <span className="tabular-nums">{yearRange}</span>
+            </span>
+            {generation.carType && (
+              <>
+                <span className="text-border" aria-hidden="true">•</span>
+                <span className="flex items-center gap-1.5">
+                  <CarIcon className="w-3.5 h-3.5" aria-hidden="true" />
+                  <span>{generation.carType.name}</span>
                 </span>
-              )}
+              </>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-between pt-3 border-t border-border">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Sparkles className="h-3 w-3 text-primary" aria-hidden="true" />
+              <span>Analyse IA disponible</span>
             </div>
-            <p className="text-sm text-muted-foreground truncate">
-              {generation.name}
-            </p>
+            <span className="flex items-center gap-1 text-xs font-medium text-primary opacity-0 group-hover:opacity-100 transition-opacity motion-reduce:transition-none" aria-hidden="true">
+              Voir la fiche
+              <ArrowRight className="h-3 w-3" aria-hidden="true" />
+            </span>
           </div>
-        </div>
-
-        {/* Metadata */}
-        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground mb-4">
-          <span className="flex items-center gap-1.5">
-            <Calendar className="w-3.5 h-3.5" aria-hidden="true" />
-            <span className="tabular-nums">{yearRange}</span>
-          </span>
-          {generation.carType && (
-            <>
-              <span className="text-border">•</span>
-              <span className="flex items-center gap-1.5">
-                <CarIcon className="w-3.5 h-3.5" aria-hidden="true" />
-                <span>{generation.carType.name}</span>
-              </span>
-            </>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="flex items-center justify-between pt-3 border-t border-border">
-          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <Sparkles className="h-3 w-3 text-primary" aria-hidden="true" />
-            <span>Analyse IA disponible</span>
-          </div>
-          <span className="flex items-center gap-1 text-xs font-medium text-primary opacity-0 group-hover:opacity-100 transition-opacity motion-reduce:transition-none">
-            Voir la fiche
-            <ArrowRight className="h-3 w-3" aria-hidden="true" />
-          </span>
         </div>
       </article>
     </Link>

--- a/src/lib/car-image.ts
+++ b/src/lib/car-image.ts
@@ -1,0 +1,37 @@
+/**
+ * Builds an imagin.studio URL for a given car make / model / year.
+ *
+ * Requires NEXT_PUBLIC_IMAGIN_CUSTOMER to be set in .env.local
+ * Sign up (free) at: https://www.imagin.studio/car-image-api
+ *
+ * Returns null when the customer ID is not configured.
+ */
+export function getImaginstudioUrl(
+  make: string,
+  model: string,
+  year?: string | null
+): string | null {
+  const customer = process.env.NEXT_PUBLIC_IMAGIN_CUSTOMER;
+  if (!customer) return null;
+
+  const slug = (s: string) =>
+    s
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9-]/g, "");
+
+  const params = new URLSearchParams({
+    customer,
+    make: slug(make),
+    modelFamily: slug(model),
+    zoomType: "fullscreen",
+    width: "640",
+  });
+
+  const cleanYear = year?.replace("NULL", "").trim();
+  if (cleanYear) params.set("modelYear", cleanYear);
+
+  return `https://cdn.imagin.studio/getimage?${params.toString()}`;
+}


### PR DESCRIPTION
Closes #20

## Résumé
- Champ `image_url` ajouté à `CarGenerationFR` et `CarGenerationEN`
- Script de seed Wikipedia/Wikimedia Commons v5 (déduplication, chiffres romains, normalisation accents)
- Composant `CarImage` avec fallback imagin.studio
- `unoptimized` sur images Wikimedia (évite les 429)
- Image en bannière dans la page détail spécification

## Test plan
- [ ] `npx tsx scripts/seed-car-images.ts --limit=20`
- [ ] Vérifier les images dans `/search`
- [ ] Vérifier la bannière dans `/specification/[id]`
- [ ] Vérifier qu'aucune erreur 429 en console

🤖 Generated with [Claude Code](https://claude.com/claude-code)